### PR TITLE
Adding missing Charge.Data field Url

### DIFF
--- a/src/main/Apis/Charge/Charge.cs
+++ b/src/main/Apis/Charge/Charge.cs
@@ -87,6 +87,9 @@ namespace PayStack.Net
 
             [JsonProperty("status")]
             public string Status { get; set; }
+            
+            [JsonProperty("url")]
+            public string Url { get; set; }
 
             [JsonProperty("reference")]
             public string Reference { get; set; }


### PR DESCRIPTION
When a open_url status comes back from the charge attempt, there is supposed to be a Url field with the URL to redirect the user to, but it is missing. Can you build and update the Nuget package with this fix?