### PR TITLE
Charge Authorization intended fix

### DIFF
--- a/src/main/Apis/Transactions/ITransactionsApi.cs
+++ b/src/main/Apis/Transactions/ITransactionsApi.cs
@@ -7,6 +7,7 @@ namespace PayStack.Net
         TransactionInitializeResponse Initialize(string email, int amount, string reference = null, bool makeReferenceUnique = false);
         TransactionInitializeResponse Initialize(TransactionInitializeRequest request, bool makeReferenceUnique = false);
         TransactionVerifyResponse Verify(string reference);
+        ChargeAuthorizationResponse ChargeAuthorization(ChargeAuthorizationRequest request);
         TransactionListResponse List(TransactionListRequest request = null);
         TransactionFetchResponse Fetch(string transactionId);
         TransactionTimelineResponse Timeline(string transactionIdOrReference);

--- a/src/main/Apis/Transactions/TransactionsApi.cs
+++ b/src/main/Apis/Transactions/TransactionsApi.cs
@@ -45,5 +45,10 @@ namespace PayStack.Net
                 "transaction/export",
                 new TransactionExportRequest { From = from, To = to, Settled = settled, PaymentPage = paymentPage }
             );
+
+        public ChargeAuthorizationResponse ChargeAuthorization(ChargeAuthorizationRequest request)
+        {
+            return _api.Post<ChargeAuthorizationResponse, ChargeAuthorizationRequest>("transaction/charge_authorization", request);
+        }
     }
 }

--- a/src/main/main.csproj
+++ b/src/main/main.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Paystack.Net</PackageId>
     <Title>PayStack API for .Net</Title>
-    <Version>0.7.2</Version>
+    <Version>0.7.2.1</Version>
     <Authors>Adebisi Foluso A.</Authors>
     <Company />
     <Product>PayStack.Net</Product>
@@ -35,6 +35,8 @@ Implements PayStack Standard Flow along with APIs for Transactions, Customers, S
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <AssemblyName>PayStack.Net</AssemblyName>
     <RootNamespace>PayStack.Net</RootNamespace>
+    <AssemblyVersion>0.7.2.1</AssemblyVersion>
+    <FileVersion>0.7.2.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />


### PR DESCRIPTION
I noticed that i could not charge authorization. Although, the previous version had a method to charge authorization under the charge API. it had a dependency for PIN which no current documentation supports. Moreover, the Charge Authorization endpoint specified was wrong. I have followed the currently used design pattern and updated the transaction API accordingly. 