### PR TITLE
Introduce ListAs to provide end users the ability to extend response contract

### DIFF
--- a/src/main/Apis/Transactions/ITransactionsApi.cs
+++ b/src/main/Apis/Transactions/ITransactionsApi.cs
@@ -4,23 +4,40 @@ namespace PayStack.Net
 {
     public interface ITransactionsApi
     {
-        TransactionInitializeResponse Initialize(string email, int amountInKobo, string reference = null, bool makeReferenceUnique = false, string currency = "NGN", string splitCode = null);
-        TransactionInitializeResponse Initialize(TransactionInitializeRequest request, bool makeReferenceUnique = false);
+        TransactionInitializeResponse Initialize(string email, int amountInKobo, string reference = null,
+            bool makeReferenceUnique = false, string currency = "NGN", string splitCode = null);
+
+        TransactionInitializeResponse Initialize(TransactionInitializeRequest request,
+            bool makeReferenceUnique = false);
+
         TransactionVerifyResponse Verify(string reference);
         TransactionListResponse List(TransactionListRequest request = null);
+        TLr ListAs<TLr>(TransactionListRequest request = null) where TLr : class, IApiResponse;
+        TransactionListResponse<TD> List<TD>(TransactionListRequest request = null);
         TransactionFetchResponse Fetch(string transactionId);
         TransactionTimelineResponse Timeline(string transactionIdOrReference);
         TransactionTotalsResponse Totals(DateTime? from = null, DateTime? to = null);
-        ChargeAuthorizationResponse ChargeAuthorization(string authorizationCode, string email, int amountInKobo, string reference = null, bool makeReferenceUnique = false);
-        ChargeAuthorizationResponse ChargeAuthorization(ChargeAuthorizationRequest request, bool makeReferenceUnique = false);
+
+        ChargeAuthorizationResponse ChargeAuthorization(string authorizationCode, string email, int amountInKobo,
+            string reference = null, bool makeReferenceUnique = false);
+
+        ChargeAuthorizationResponse ChargeAuthorization(ChargeAuthorizationRequest request,
+            bool makeReferenceUnique = false);
+
         TransactionExportResponse Export(DateTime? from = null, DateTime? to = null,
             bool settled = false, string paymentPage = null);
-        ReAuthorizationResponse RequestReAuthorization(string authorizationCode, string email, int amountInKobo, string reference = null, bool makeReferenceUnique = false);
-        ReAuthorizationResponse RequestReAuthorization(ReAuthorizationRequest request, bool makeReferenceUnique = false);
+
+        ReAuthorizationResponse RequestReAuthorization(string authorizationCode, string email, int amountInKobo,
+            string reference = null, bool makeReferenceUnique = false);
+
+        ReAuthorizationResponse
+            RequestReAuthorization(ReAuthorizationRequest request, bool makeReferenceUnique = false);
 
         CheckAuthorizationResponse CheckAuthorization(string authorizationCode, string email, int amountInKobo);
         CheckAuthorizationResponse CheckAuthorization(CheckAuthorizationRequest request);
         TransactionPartialDebitResponse PartialDebit(TransactionPartialDebitRequest request);
-        TransactionPartialDebitResponse PartialDebit(string authorizationCode, string currency, string amount, string email);
+
+        TransactionPartialDebitResponse PartialDebit(string authorizationCode, string currency, string amount,
+            string email);
     }
 }

--- a/src/main/Apis/Transactions/List.cs
+++ b/src/main/Apis/Transactions/List.cs
@@ -8,170 +8,136 @@ namespace PayStack.Net
     {
         public class History
         {
-            [JsonProperty("type")]
-            public string Type { get; set; }
+            [JsonProperty("type")] public string Type { get; set; }
 
-            [JsonProperty("message")]
-            public string Message { get; set; }
+            [JsonProperty("message")] public string Message { get; set; }
 
-            [JsonProperty("time")]
-            public int Time { get; set; }
+            [JsonProperty("time")] public int Time { get; set; }
         }
 
         public class Log
         {
-            [JsonProperty("time_spent")]
-            public int TimeSpent { get; set; }
+            [JsonProperty("time_spent")] public int TimeSpent { get; set; }
 
-            [JsonProperty("attempts")]
-            public int Attempts { get; set; }
+            [JsonProperty("attempts")] public int Attempts { get; set; }
 
-            [JsonProperty("authentication")]
-            public object Authentication { get; set; }
+            [JsonProperty("authentication")] public object Authentication { get; set; }
 
-            [JsonProperty("errors")]
-            public int Errors { get; set; }
+            [JsonProperty("errors")] public int Errors { get; set; }
 
-            [JsonProperty("success")]
-            public bool Success { get; set; }
+            [JsonProperty("success")] public bool Success { get; set; }
 
-            [JsonProperty("mobile")]
-            public bool Mobile { get; set; }
+            [JsonProperty("mobile")] public bool Mobile { get; set; }
 
-            [JsonProperty("input")]
-            public IList<object> Input { get; set; }
+            [JsonProperty("input")] public IList<object> Input { get; set; }
 
-            [JsonProperty("channel")]
-            public object Channel { get; set; }
+            [JsonProperty("channel")] public object Channel { get; set; }
 
-            [JsonProperty("history")]
-            public IList<History> Histories { get; set; }
+            [JsonProperty("history")] public IList<History> Histories { get; set; }
         }
 
         public class Authorization
         {
-            [JsonProperty("authorization_code")]
-            public string AuthorizationCode { get; set; }
+            [JsonProperty("authorization_code")] public string AuthorizationCode { get; set; }
 
-            [JsonProperty("bin")]
-            public string Bin { get; set; }
+            [JsonProperty("bin")] public string Bin { get; set; }
 
-            [JsonProperty("last4")]
-            public string Last4 { get; set; }
+            [JsonProperty("last4")] public string Last4 { get; set; }
 
-            [JsonProperty("exp_month")]
-            public string ExpMonth { get; set; }
+            [JsonProperty("exp_month")] public string ExpMonth { get; set; }
 
-            [JsonProperty("exp_year")]
-            public string ExpYear { get; set; }
+            [JsonProperty("exp_year")] public string ExpYear { get; set; }
 
-            [JsonProperty("card_type")]
-            public string CardType { get; set; }
+            [JsonProperty("card_type")] public string CardType { get; set; }
 
-            [JsonProperty("bank")]
-            public string Bank { get; set; }
+            [JsonProperty("bank")] public string Bank { get; set; }
 
-            [JsonProperty("country_code")]
-            public string CountryCode { get; set; }
+            [JsonProperty("country_code")] public string CountryCode { get; set; }
 
-            [JsonProperty("reusable")]
-            public bool? Reusable { get; set; }
+            [JsonProperty("reusable")] public bool? Reusable { get; set; }
 
-            [JsonProperty("brand")]
-            public string Brand { get; set; }
+            [JsonProperty("brand")] public string Brand { get; set; }
 
-            [JsonProperty("channel")]
-            public string Channel { get; set; }
+            [JsonProperty("channel")] public string Channel { get; set; }
         }
 
         public class Customer
         {
-            [JsonProperty("id")]
-            public int Id { get; set; }
+            [JsonProperty("id")] public int Id { get; set; }
 
-            [JsonProperty("email")]
-            public string Email { get; set; }
+            [JsonProperty("email")] public string Email { get; set; }
 
-            [JsonProperty("customer_code")]
-            public string CustomerCode { get; set; }
+            [JsonProperty("customer_code")] public string CustomerCode { get; set; }
 
-            [JsonProperty("risk_action")]
-            public string RiskAction { get; set; }
+            [JsonProperty("risk_action")] public string RiskAction { get; set; }
         }
 
         public class Datum
         {
-            [JsonProperty("id")]
-            public long Id { get; set; }
+            [JsonProperty("id")] public long Id { get; set; }
 
-            [JsonProperty("domain")]
-            public string Domain { get; set; }
+            [JsonProperty("domain")] public string Domain { get; set; }
 
-            [JsonProperty("status")]
-            public string Status { get; set; }
+            [JsonProperty("status")] public string Status { get; set; }
 
-            [JsonProperty("reference")]
-            public string Reference { get; set; }
+            [JsonProperty("reference")] public string Reference { get; set; }
 
-            [JsonProperty("amount")]
-            public int Amount { get; set; }
+            [JsonProperty("amount")] public int Amount { get; set; }
 
-            [JsonProperty("gateway_response")]
-            public string GatewayResponse { get; set; }
+            [JsonProperty("gateway_response")] public string GatewayResponse { get; set; }
 
-            [JsonProperty("paid_at")]
-            public DateTime? PaidAt { get; set; }
+            [JsonProperty("paid_at")] public DateTime? PaidAt { get; set; }
 
-            [JsonProperty("created_at")]
-            public DateTime CreatedAt { get; set; }
+            [JsonProperty("created_at")] public DateTime CreatedAt { get; set; }
 
-            [JsonProperty("channel")]
-            public string Channel { get; set; }
+            [JsonProperty("channel")] public string Channel { get; set; }
 
-            [JsonProperty("currency")]
-            public string Currency { get; set; }
+            [JsonProperty("currency")] public string Currency { get; set; }
 
-            [JsonProperty("ip_address")]
-            public string IpAddress { get; set; }
+            [JsonProperty("ip_address")] public string IpAddress { get; set; }
 
-            [JsonProperty("metadata")]
-            public Metadata Metadata { get; set; }
+            [JsonProperty("metadata")] public Metadata Metadata { get; set; }
 
-            [JsonProperty("log")]
-            public Log Log { get; set; }
+            [JsonProperty("log")] public Log Log { get; set; }
 
-            [JsonProperty("fees")]
-            public string Fees { get; set; }
+            [JsonProperty("fees")] public string Fees { get; set; }
 
-            [JsonProperty("paidAt")]
-            public DateTime? PaidAtRedundant { get; set; }
+            [JsonProperty("paidAt")] public DateTime? PaidAtRedundant { get; set; }
 
-            [JsonProperty("createdAt")]
-            public DateTime CreatedAtRedundant { get; set; }
+            [JsonProperty("createdAt")] public DateTime CreatedAtRedundant { get; set; }
 
-            [JsonProperty("authorization")]
-            public Authorization Authorization { get; set; }
+            [JsonProperty("authorization")] public Authorization Authorization { get; set; }
 
-            [JsonProperty("customer")]
-            public Customer Customer { get; set; }
+            [JsonProperty("customer")] public Customer Customer { get; set; }
+            [JsonProperty("fees_split")] public FeesSplit FeesSplit { get; set; }
+        }
+
+        public class FeesSplit
+        {
+            [JsonProperty("paystack")] public int Paystack { get; set; }
+            [JsonProperty("integration")] public int Integration { get; set; }
+            [JsonProperty("subaccount")] public int SubAccount { get; set; }
+            [JsonProperty("params")] public FeesParams FeesParams { get; set; }
+        }
+
+        public class FeesParams
+        {
+            [JsonProperty("bearer")] public string Bearer { get; set; }
+            [JsonProperty("transaction_charge")] public string TransactionCharge { get; set; }
+            [JsonProperty("percentage_charge")] public string PercentageCharge { get; set; }
         }
 
         public class Meta
         {
-            [JsonProperty("total")]
-            public int Total { get; set; }
+            [JsonProperty("total")] public int Total { get; set; }
 
-            [JsonProperty("total_volume")]
-            public long TotalVolume { get; set; }
+            [JsonProperty("total_volume")] public long TotalVolume { get; set; }
 
-            [JsonProperty("perPage")]
-            public string PerPage { get; set; }
+            [JsonProperty("perPage")] public string PerPage { get; set; }
 
-            [JsonProperty("page")]
-            public int Page { get; set; }
+            [JsonProperty("page")] public int Page { get; set; }
 
-            [JsonProperty("pageCount")]
-            public int PageCount { get; set; }
+            [JsonProperty("pageCount")] public int PageCount { get; set; }
         }
     }
 
@@ -194,16 +160,23 @@ namespace PayStack.Net
 
     public class TransactionListResponse : HasRawResponse, IApiResponse
     {
-        [JsonProperty("status")]
-        public bool Status { get; set; }
+        [JsonProperty("status")] public bool Status { get; set; }
 
-        [JsonProperty("message")]
-        public string Message { get; set; }
+        [JsonProperty("message")] public string Message { get; set; }
 
-        [JsonProperty("data")]
-        public IList<TransactionList.Datum> Data { get; set; }
+        [JsonProperty("data")] public IList<TransactionList.Datum> Data { get; set; }
 
-        [JsonProperty("meta")]
-        public TransactionList.Meta Meta { get; set; }
+        [JsonProperty("meta")] public TransactionList.Meta Meta { get; set; }
+    }
+
+    public class TransactionListResponse<TD> : HasRawResponse, IApiResponse
+    {
+        [JsonProperty("status")] public bool Status { get; set; }
+
+        [JsonProperty("message")] public string Message { get; set; }
+
+        [JsonProperty("data")] public IList<TD> Data { get; set; }
+
+        [JsonProperty("meta")] public TransactionList.Meta Meta { get; set; }
     }
 }

--- a/src/main/Apis/Transactions/TransactionsApi.cs
+++ b/src/main/Apis/Transactions/TransactionsApi.cs
@@ -11,22 +11,38 @@ namespace PayStack.Net
             _api = api;
         }
 
-        public TransactionInitializeResponse Initialize(string email, int amount, string reference = null, bool makeReferenceUnique = false, string currency = "NGN", string splitCode = null)
-            => Initialize(new TransactionInitializeRequest { Reference = reference, Email = email, AmountInKobo = amount, Currency = currency, SplitCode = splitCode }, makeReferenceUnique);
+        public TransactionInitializeResponse Initialize(string email, int amount, string reference = null,
+            bool makeReferenceUnique = false, string currency = "NGN", string splitCode = null)
+            => Initialize(
+                new TransactionInitializeRequest
+                {
+                    Reference = reference, Email = email, AmountInKobo = amount, Currency = currency,
+                    SplitCode = splitCode
+                }, makeReferenceUnique);
 
-        public TransactionInitializeResponse Initialize(TransactionInitializeRequest request, bool makeReferenceUnique = false)
+        public TransactionInitializeResponse Initialize(TransactionInitializeRequest request,
+            bool makeReferenceUnique = false)
         {
             if (makeReferenceUnique && request.Reference != null)
                 request.Reference = $"{request.Reference}-{Guid.NewGuid().ToString().Substring(0, 8)}";
-            return _api.Post<TransactionInitializeResponse, TransactionInitializeRequest>("transaction/initialize", request);
+            return _api.Post<TransactionInitializeResponse, TransactionInitializeRequest>("transaction/initialize",
+                request);
         }
 
 
         public TransactionVerifyResponse Verify(string reference) =>
-                _api.Get<TransactionVerifyResponse>($"transaction/verify/{reference}");
+            _api.Get<TransactionVerifyResponse>($"transaction/verify/{reference}");
 
         public TransactionListResponse List(TransactionListRequest request = null) =>
             _api.Get<TransactionListResponse, TransactionListRequest>("transaction", request);
+
+        public TLr ListAs<TLr>(TransactionListRequest request = null) where TLr : class, IApiResponse
+        {
+            return _api.Get<TLr, TransactionListRequest>("transaction", request);
+        }
+
+        public TransactionListResponse<TD> List<TD>(TransactionListRequest request = null) =>
+            _api.Get<TransactionListResponse<TD>, TransactionListRequest>("transaction", request);
 
         public TransactionFetchResponse Fetch(string transactionId) =>
             _api.Get<TransactionFetchResponse>($"transaction/{transactionId}");
@@ -46,7 +62,8 @@ namespace PayStack.Net
                 new TransactionExportRequest { From = from, To = to, Settled = settled, Payment_Page = paymentPage }
             );
 
-        public ChargeAuthorizationResponse ChargeAuthorization(string authorizationCode, string email, int amountInKobo, string reference = null, bool makeReferenceUnique = false) =>
+        public ChargeAuthorizationResponse ChargeAuthorization(string authorizationCode, string email, int amountInKobo,
+            string reference = null, bool makeReferenceUnique = false) =>
             ChargeAuthorization(new ChargeAuthorizationRequest
             {
                 Reference = reference,
@@ -55,7 +72,8 @@ namespace PayStack.Net
                 AmountInKobo = amountInKobo
             }, makeReferenceUnique);
 
-        public ChargeAuthorizationResponse ChargeAuthorization(ChargeAuthorizationRequest request, bool makeReferenceUnique = false)
+        public ChargeAuthorizationResponse ChargeAuthorization(ChargeAuthorizationRequest request,
+            bool makeReferenceUnique = false)
         {
             if (makeReferenceUnique && request.Reference != null)
                 request.Reference = $"{request.Reference}-{Guid.NewGuid().ToString().Substring(0, 8)}";
@@ -64,7 +82,8 @@ namespace PayStack.Net
             );
         }
 
-        public ReAuthorizationResponse RequestReAuthorization(string authorizationCode, string email, int amountInKobo, string reference = null, bool makeReferenceUnique = false) =>
+        public ReAuthorizationResponse RequestReAuthorization(string authorizationCode, string email, int amountInKobo,
+            string reference = null, bool makeReferenceUnique = false) =>
             RequestReAuthorization(new ReAuthorizationRequest
             {
                 AuthorizationCode = authorizationCode,
@@ -73,7 +92,8 @@ namespace PayStack.Net
                 Reference = reference
             }, makeReferenceUnique);
 
-        public ReAuthorizationResponse RequestReAuthorization(ReAuthorizationRequest request, bool makeReferenceUnique = false)
+        public ReAuthorizationResponse RequestReAuthorization(ReAuthorizationRequest request,
+            bool makeReferenceUnique = false)
         {
             if (makeReferenceUnique && request.Reference != null)
                 request.Reference = $"{request.Reference}-{Guid.NewGuid().ToString().Substring(0, 8)}";
@@ -82,7 +102,8 @@ namespace PayStack.Net
             );
         }
 
-        public CheckAuthorizationResponse CheckAuthorization(string authorizationCode, string email, int amountInKobo) =>
+        public CheckAuthorizationResponse
+            CheckAuthorization(string authorizationCode, string email, int amountInKobo) =>
             CheckAuthorization(new CheckAuthorizationRequest
             {
                 AuthorizationCode = authorizationCode,
@@ -100,7 +121,8 @@ namespace PayStack.Net
                 "transaction/partial_debit", request
             );
 
-        public TransactionPartialDebitResponse PartialDebit(string authorizationCode, string currency, string amount, string email) =>
+        public TransactionPartialDebitResponse PartialDebit(string authorizationCode, string currency, string amount,
+            string email) =>
             PartialDebit(new TransactionPartialDebitRequest
             {
                 AuthorizationCode = authorizationCode,

--- a/src/main/PayStackApi.cs
+++ b/src/main/PayStackApi.cs
@@ -74,9 +74,9 @@ namespace PayStack.Net
         public TR Post<TR, T>(string relativeUrl, T request) where TR : IApiResponse
         {
             var rawJson = _client.PostAsync(
-                    relativeUrl.TrimStart('/'),
-                    new StringContent(PrepareRequest(request))
-                ).Result.Content.ReadAsStringAsync().Result;
+                relativeUrl.TrimStart('/'),
+                new StringContent(PrepareRequest(request))
+            ).Result.Content.ReadAsStringAsync().Result;
 
             return ParseAndResolveMetadata<TR>(ref rawJson);
         }
@@ -104,9 +104,9 @@ namespace PayStack.Net
         public TR Put<TR, T>(string relativeUrl, T request) where TR : IApiResponse
         {
             var rawJson = _client.PutAsync(
-                    relativeUrl.TrimStart('/'),
-                    new StringContent(PrepareRequest(request))
-                ).Result.Content.ReadAsStringAsync().Result;
+                relativeUrl.TrimStart('/'),
+                new StringContent(PrepareRequest(request))
+            ).Result.Content.ReadAsStringAsync().Result;
 
             return ParseAndResolveMetadata<TR>(ref rawJson);
         }
@@ -117,14 +117,15 @@ namespace PayStack.Net
             var preparable = request as IPreparable;
 
             var queryString = "";
-            
+
             if (preparable != null)
                 preparable.Prepare();
-            
+
             if (request != null)
                 queryString = $"?{request.ToQueryString()}";
-            
-            var rawJson = _client.GetAsync(relativeUrl.TrimStart('/') + queryString).Result.Content.ReadAsStringAsync().Result;
+
+            var rawJson = _client.GetAsync(relativeUrl.TrimStart('/') + queryString).Result.Content.ReadAsStringAsync()
+                .Result;
             return ParseAndResolveMetadata<TR>(ref rawJson);
         }
 

--- a/src/test-console/Program.cs
+++ b/src/test-console/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using Newtonsoft.Json;
 using PayStack.Net;
@@ -88,6 +89,8 @@ namespace test_console
             // TransactionFetch_Setup();
             //TransactionList_Setup();
             //TransactionList_Filtered_Setup();
+            //TransactionList_Generic_Filtered_Setup();
+            //TransactionList_Generic_With_FullResponse_Filtered_Setup();
             // InitializeRequest_Setup();
             // VerifyPaymentReference();
         }
@@ -215,6 +218,32 @@ namespace test_console
             _api.Transactions.List(request).Print();
         }
 
+        private static void TransactionList_Generic_Filtered_Setup()
+        {
+            var request = new TransactionListRequest
+            {
+                PerPage = 10,
+                Page = 1,
+                From = new DateTime(2023, 1, 1),
+                To = new DateTime(2023, 12, 31),
+            };
+
+            _api.Transactions.List<TransactionListResponseData>(request).Print();
+        }
+
+        private static void TransactionList_Generic_With_FullResponse_Filtered_Setup()
+        {
+            var request = new TransactionListRequest
+            {
+                PerPage = 10,
+                Page = 1,
+                From = new DateTime(2023, 1, 1),
+                To = new DateTime(2023, 12, 31),
+            };
+
+            var test = _api.Transactions.ListAs<CustomTransactionListResponse>(request);
+            _api.Transactions.ListAs<CustomTransactionListResponse>(request).Print();
+        }
 
         private static void InitializeRequest_Setup()
         {
@@ -249,6 +278,58 @@ namespace test_console
             Console.WriteLine("Response");
             response.Print();
         }
+    }
+
+    public class CustomTransactionListResponse : IApiResponse
+    {
+        [JsonProperty("status")] public bool Status { get; set; }
+
+        [JsonProperty("message")] public string Message { get; set; }
+
+        [JsonProperty("data")] public IList<TransactionListResponseData> Data { get; set; }
+
+        [JsonProperty("meta")] public TransactionList.Meta Meta { get; set; }
+    }
+
+    public class TransactionListResponseData
+    {
+        [JsonProperty("id")] public long Id { get; set; }
+
+        [JsonProperty("domain")] public string Domain { get; set; }
+
+        [JsonProperty("status")] public string Status { get; set; }
+
+        [JsonProperty("reference")] public string Reference { get; set; }
+
+        [JsonProperty("amount")] public int Amount { get; set; }
+
+        [JsonProperty("gateway_response")] public string GatewayResponse { get; set; }
+
+        [JsonProperty("paid_at")] public DateTime? PaidAt { get; set; }
+
+        [JsonProperty("created_at")] public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("channel")] public string Channel { get; set; }
+
+        [JsonProperty("currency")] public string Currency { get; set; }
+
+        [JsonProperty("ip_address")] public string IpAddress { get; set; }
+
+        [JsonProperty("metadata")] public Metadata Metadata { get; set; }
+
+        [JsonProperty("log")] public TransactionList.Log Log { get; set; }
+
+        [JsonProperty("fees")] public string Fees { get; set; }
+
+        [JsonProperty("paidAt")] public DateTime? PaidAtRedundant { get; set; }
+
+        [JsonProperty("createdAt")] public DateTime CreatedAtRedundant { get; set; }
+
+        [JsonProperty("authorization")] public TransactionList.Authorization Authorization { get; set; }
+
+        [JsonProperty("customer")] public TransactionList.Customer Customer { get; set; }
+
+        [JsonProperty("fees_split")] public TransactionList.FeesSplit FeesSplit { get; set; }
     }
 
     public static class Extensions


### PR DESCRIPTION
Introduced `ListAs` to provide end users the ability to extend the response contract.

Paystack responses will be updated more frequently to accommodate new functionality. 

This provides a user with a way to extend the entire response or the data property of the existing response. 

The idea is to 

```
public class CustomTransactionListResponse
{
  //You can define your contract
}

_api.Transactions.ListAs<CustomTransactionListResponse>(request);
```

Additionally, there is an overload of the existing `List` that allows you to pass just the contract of the Data property of the standard Paystack response.

```
public class CustomTransactionListDataResponse
{
  //You can define your contract
}

_api.Transactions.List<CustomTransactionListResponse>(request);
```

I also added the FeeSplit contract to the existing contract. But those above will allow users a way to do what they want before the contracts are updated in the library